### PR TITLE
Fix script auto-execution and add main function

### DIFF
--- a/anagramFinder.py
+++ b/anagramFinder.py
@@ -3,29 +3,37 @@
 from collections import defaultdict
 import time
 
-start_time = time.time()
 
-try:
-    with open("anagram.txt") as fileobj:
-        words = fileobj.read().splitlines()
-except FileNotFoundError as e:
-    print(e)
+def find_anagrams(filepath="anagram.txt"):
+    """Return a list of anagram words from *filepath* and print execution time."""
+    start_time = time.time()
+    try:
+        with open(filepath) as fileobj:
+            words = fileobj.read().splitlines()
+    except FileNotFoundError as e:
+        print(e)
+        return []
 
-# Group words based on their lengths using defaultdict(list)
-word_groups = defaultdict(list)
-for word in words:
-    word_groups[len(word)].append(word)
+    # Group words based on their lengths using defaultdict(list)
+    word_groups = defaultdict(list)
+    for word in words:
+        word_groups[len(word)].append(word)
 
-# Find anagram words using a dictionary
-anagram_words = []
-anagram_dict = defaultdict(list)
-for word in words:
-    sorted_word = ''.join(sorted(word))
-    anagram_dict[sorted_word].append(word)
+    # Find anagram words using a dictionary
+    anagram_words = []
+    anagram_dict = defaultdict(list)
+    for word in words:
+        sorted_word = "".join(sorted(word))
+        anagram_dict[sorted_word].append(word)
 
-for sorted_word, anagrams in anagram_dict.items():
-    if len(anagrams) > 1:
-        anagram_words.extend(anagrams)
+    for anagrams in anagram_dict.values():
+        if len(anagrams) > 1:
+            anagram_words.extend(anagrams)
 
-# print(anagram_words)
-print(time.time() - start_time)
+    # print(anagram_words)
+    print(time.time() - start_time)
+    return anagram_words
+
+
+if __name__ == "__main__":
+    find_anagrams()


### PR DESCRIPTION
## Summary
- avoid running the anagram finder on import by wrapping the logic in `find_anagrams`
- add a conventional `if __name__ == "__main__"` guard

## Testing
- `python anagramFinder.py | head`
- `python - <<'PY'
import anagramFinder
print('import test done')
PY`


------
https://chatgpt.com/codex/tasks/task_e_687e57db9ffc832a8d5ec0f520ffcc21